### PR TITLE
Return early when the longest string is 2 chars long

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = (function()
     la -= offset;
     lb -= offset;
 
-    if (la === 0 || lb === 1) {
+    if (la === 0 || lb < 3) {
       return lb;
     }
 


### PR DESCRIPTION
When `lb` is 2 in this case, it means that `a` is either:

* one char, which is not present in `b` (otherwise it would have been eaten by prefix or suffix elimination)
* two chars, where `a[0] != b[0] && a[1] != b[1]`

In both cases the Levenstein distance is 2.