### PR TITLE
Add Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'js-levenshtein' {
+	export default function(a: string, b: string): number;
+}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,8 @@
     "test": "ava",
     "bench": "matcha bench.js"
   },
-  "files": [
-    "index.js",
-    "index.d.ts"
-  ],
+  "main": "index.js",
+  "types": "index.d.ts",
   "keywords": [
     "levenshtein",
     "distance",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "bench": "matcha bench.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "keywords": [
     "levenshtein",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   },
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "keywords": [
     "levenshtein",
     "distance",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
-    "index.js",
     "index.d.ts"
   ],
   "keywords": [


### PR DESCRIPTION
I added a TypeScript declaration file.

In case you're unfamiliar with this format, I'll explain it a little:
* `declare module 'js-levenshtein'`: this declares what module the types will be for (this one, of course)
* `export`: this is how things are exported in TS and ESM, equivalent to assigning to `exports` in CJS (which is the traditional module resolution in NodeJS)
* `export default`: this means that it's specifically the main export, equivalent to doing `module.exports = something` in CJS
* `function(a: string, b: string): number;`: this represents the actual function exported by the module. It doesn't have a name, since it's the `default` export. It takes two strings and returns a number.

Let me know if I missed anything or got the types wrong.

Fixes #7 