### PR TITLE
Update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,28 @@ levenshtein('kitten', 'sitting');
 $ npm run bench
 
                       50 paragraphs, length max=500 min=240 avr=372.5
+            672 op/s » fastest-levenshtein
+            612 op/s » fast-levenshtein 
             121 op/s » js-levenshtein
              78 op/s » talisman
              71 op/s » levenshtein-edit-distance
              71 op/s » leven
-             52 op/s » fast-levenshtein 
-             672 op/s » fastest-levenshtein
 
                       100 sentences, length max=170 min=6 avr=57.5
+          10,551 op/s » fastest-levenshtein
+           9,851 op/s » fast-levenshtein
            2,326 op/s » js-levenshtein
            1,647 op/s » talisman
            1,377 op/s » levenshtein-edit-distance
            1,378 op/s » leven
-           1,087 op/s » fast-levenshtein
-          10,551 op/s » fastest-levenshtein
 
                       2000 words, length max=20 min=3 avr=9.5
+           7,528 op/s » fastest-levenshtein 
+           7,228 op/s » fast-levenshtein
            2,659 op/s » js-levenshtein
            2,186 op/s » talisman
            1,847 op/s » levenshtein-edit-distance
            1,906 op/s » leven
-           1,672 op/s » fast-levenshtein
-           7,528 op/s » fastest-levenshtein 
 ```
 
 Benchmarks were performed with node v14.7.0 on a Pentium G4560 @ 3.50 GHz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# js-levenshtein [![Build Status](https://travis-ci.org/gustf/js-levenshtein.svg?branch=master)](https://travis-ci.org/gustf/js-levenshtein)
+﻿# js-levenshtein [![Build Status](https://travis-ci.org/gustf/js-levenshtein.svg?branch=master)](https://travis-ci.org/gustf/js-levenshtein)
 
 A very efficient JS implementation calculating the Levenshtein distance, i.e. the difference between two strings.
 
@@ -30,30 +30,33 @@ levenshtein('kitten', 'sitting');
 
 ```
 $ npm run bench
-  
+
                       50 paragraphs, length max=500 min=240 avr=372.5
-             162 op/s » js-levenshtein
-              98 op/s » talisman
-              94 op/s » levenshtein-edit-distance
-              85 op/s » leven
-              39 op/s » fast-levenshtein
+            121 op/s » js-levenshtein
+             78 op/s » talisman
+             71 op/s » levenshtein-edit-distance
+             71 op/s » leven
+             52 op/s » fast-levenshtein 
+             672 op/s » fastest-levenshtein
 
                       100 sentences, length max=170 min=6 avr=57.5
-           3,076 op/s » js-levenshtein
-           2,024 op/s » talisman
-           1,817 op/s » levenshtein-edit-distance
-           1,633 op/s » leven
-             800 op/s » fast-levenshtein
+           2,326 op/s » js-levenshtein
+           1,647 op/s » talisman
+           1,377 op/s » levenshtein-edit-distance
+           1,378 op/s » leven
+           1,087 op/s » fast-levenshtein
+          10,551 op/s » fastest-levenshtein
 
                       2000 words, length max=20 min=3 avr=9.5
-           3,119 op/s » js-levenshtein
-           2,416 op/s » talisman
-           2,141 op/s » levenshtein-edit-distance
-           1,855 op/s » leven
-           1,260 op/s » fast-levenshtein
+           2,659 op/s » js-levenshtein
+           2,186 op/s » talisman
+           1,847 op/s » levenshtein-edit-distance
+           1,906 op/s » leven
+           1,672 op/s » fast-levenshtein
+           7,528 op/s » fastest-levenshtein 
 ```
 
-Benchmarks was performed with node v8.12.0 on a MacBook Pro 15", 2.9 GHz Intel Core i9
+Benchmarks were performed with node v14.7.0 on a Pentium G4560 @ 3.50 GHz
 
 ## License
 

--- a/bench.js
+++ b/bench.js
@@ -42,6 +42,14 @@ suite('50 paragraphs, length max=500 min=240 avr=372.5', function() {
     }
   });
 
+  bench('fastest-levenshtein', function() {
+    paragraphBench(distance);
+  });
+
+  bench('fast-levenshtein', function() {
+    paragraphBench(fastLevenshtein);
+  });
+
   bench('js-levenshtein', function() {
     paragraphBench(levenshtein);
   });
@@ -57,14 +65,6 @@ suite('50 paragraphs, length max=500 min=240 avr=372.5', function() {
   bench('leven', function() {
     paragraphBench(leven);
   });
-
-  bench('fast-levenshtein', function() {
-    paragraphBench(fastLevenshtein);
-  });
-
-  bench('fastest-levenshtein', function() {
-    paragraphBench(distance);
-  });
 });
 
 suite('100 sentences, length max=170 min=6 avr=57.5', function() {
@@ -74,6 +74,13 @@ suite('100 sentences, length max=170 min=6 avr=57.5', function() {
     for (var i = 0; i < sentences.length; i++) {
       _t += sentences[i].toLowerCase().length;
     }
+  });
+  bench('fastest-levenshtein', function() {
+    sentenceBench(distance);
+  });
+
+  bench('fast-levenshtein', function() {
+    sentenceBench(fastLevenshtein);
   });
 
   bench('js-levenshtein', function() {
@@ -91,14 +98,6 @@ suite('100 sentences, length max=170 min=6 avr=57.5', function() {
   bench('leven', function() {
     sentenceBench(leven);
   });
-
-  bench('fast-levenshtein', function() {
-    sentenceBench(fastLevenshtein);
-  });
-
-  bench('fastest-levenshtein', function() {
-    sentenceBench(distance);
-  });
 });
 
 suite('2000 words, length max=20 min=3 avr=9.5', function() {
@@ -108,6 +107,14 @@ suite('2000 words, length max=20 min=3 avr=9.5', function() {
     for (var i = 0; i < words.length; i++) {
       _t += words[i].toLowerCase().length;
     }
+  });
+
+  bench('fastest-levenshtein', function() {
+    wordBench(distance);
+  });
+
+  bench('fast-levenshtein', function() {
+    wordBench(fastLevenshtein);
   });
 
   bench('js-levenshtein', function() {
@@ -124,14 +131,6 @@ suite('2000 words, length max=20 min=3 avr=9.5', function() {
 
   bench('leven', function() {
     wordBench(leven);
-  });
-
-  bench('fast-levenshtein', function() {
-    wordBench(fastLevenshtein);
-  });
-
-  bench('fastest-levenshtein', function() {
-    wordBench(distance);
   });
 });
 

--- a/bench.js
+++ b/bench.js
@@ -3,6 +3,7 @@ const levenshteinEditDistance = require('levenshtein-edit-distance');
 const fastLevenshtein = require('fast-levenshtein').get;
 const talisman = require('talisman/metrics/distance/levenshtein');
 const leven = require('leven');
+const {distance} = require('fastest-levenshtein')
 const levenshtein = require('./');
 
 function wordBench(fn)
@@ -60,6 +61,10 @@ suite('50 paragraphs, length max=500 min=240 avr=372.5', function() {
   bench('fast-levenshtein', function() {
     paragraphBench(fastLevenshtein);
   });
+
+  bench('fastest-levenshtein', function() {
+    paragraphBench(distance);
+  });
 });
 
 suite('100 sentences, length max=170 min=6 avr=57.5', function() {
@@ -90,6 +95,10 @@ suite('100 sentences, length max=170 min=6 avr=57.5', function() {
   bench('fast-levenshtein', function() {
     sentenceBench(fastLevenshtein);
   });
+
+  bench('fastest-levenshtein', function() {
+    sentenceBench(distance);
+  });
 });
 
 suite('2000 words, length max=20 min=3 avr=9.5', function() {
@@ -119,6 +128,10 @@ suite('2000 words, length max=20 min=3 avr=9.5', function() {
 
   bench('fast-levenshtein', function() {
     wordBench(fastLevenshtein);
+  });
+
+  bench('fastest-levenshtein', function() {
+    wordBench(distance);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   ],
   "devDependencies": {
     "ava": "^0.25.0",
-    "fast-levenshtein": "^2.0.6",
+    "fast-levenshtein": "^3.0.0",
     "fastest-levenshtein": "^1.0.10",
+    "leven": "^2.1.0",
     "levenshtein-edit-distance": "^2.0.3",
     "matcha": "^0.7.0",
     "talisman": "^0.21.0",
-    "leven": "^2.1.0",
     "xo": "^0.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "fast-levenshtein": "^2.0.6",
+    "fastest-levenshtein": "^1.0.10",
     "levenshtein-edit-distance": "^2.0.3",
     "matcha": "^0.7.0",
     "talisman": "^0.21.0",


### PR DESCRIPTION
This PR:
* Updates the benchmarks in the README to be on the latest Node version (v14.7.0).
* Updates `fast-levenshtein` to version (v3.0.0).
* Adds [`fastest-levenshtein`](https://github.com/ka-weihe/fastest-levenshtein) to the benchmark-suite.

I would also suggest changing the about section of this repo. 